### PR TITLE
Potential fix for code scanning alert no. 1: Useless regular-expression character escape

### DIFF
--- a/assets/vendor/codemirror/codemirror.js
+++ b/assets/vendor/codemirror/codemirror.js
@@ -1677,7 +1677,7 @@ function extractLineClasses(type, output) {
     var prop = lineClass[1] ? "bgClass" : "textClass"
     if (output[prop] == null)
       { output[prop] = lineClass[2] }
-    else if (!(new RegExp("(?:^|\s)" + lineClass[2] + "(?:$|\s)")).test(output[prop]))
+    else if (!(new RegExp("(?:^|\\s)" + lineClass[2] + "(?:$|\\s)")).test(output[prop]))
       { output[prop] += " " + lineClass[2] }
   } }
   return type


### PR DESCRIPTION
Potential fix for [https://github.com/cp-psource/ps-dsgvo/security/code-scanning/1](https://github.com/cp-psource/ps-dsgvo/security/code-scanning/1)

To fix the issue, the string literal containing the regular expression should use double backslashes (`\\s`) to correctly escape the `\s` sequence. This ensures that the resulting regular expression interprets `\s` as a whitespace character class. The fix involves modifying the string on line 1680 to include the correct number of backslashes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
